### PR TITLE
Fix ticker intervals and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a Telegram bot built using Go that allows users to upload word pairs and
 
 ## Features
 
-- Upload word pairs in the format `word1,word2`.
+- Upload word pairs as a tab separated CSV (`word1\tword2`).
 - Clear uploaded word pairs.
 - Set the number of pairs to send in reminders.
 - Set the frequency of reminders per day.

--- a/pkg/bot/tickers.go
+++ b/pkg/bot/tickers.go
@@ -60,11 +60,15 @@ func createUserTicker(user db.UserSettings) struct {
 	user   db.UserSettings
 } {
 	var ticker *time.Ticker
-	if user.RemindersPerDay > 24 {
+	switch {
+	case user.RemindersPerDay >= 24*60:
+		ticker = time.NewTicker(time.Minute)
+	case user.RemindersPerDay > 24:
 		interval := time.Duration(24*60/user.RemindersPerDay) * time.Minute
 		ticker = time.NewTicker(interval)
-	} else {
-		ticker = time.NewTicker(time.Duration(24 * int(time.Hour) / user.RemindersPerDay))
+	default:
+		interval := 24 * time.Hour / time.Duration(user.RemindersPerDay)
+		ticker = time.NewTicker(interval)
 	}
 	return struct {
 		ticker *time.Ticker


### PR DESCRIPTION
## Summary
- prevent ticker interval overflow
- document tab-separated word pair format

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6841fc8c0eac83228bd58112c7e152c9