### PR TITLE
Add interactive /game quiz mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This is a Telegram bot built using Go that allows users to upload word pairs and
 - Set the number of pairs to send in reminders.
 - Set the frequency of reminders per day.
 - Periodic reminders sent to users with random word pairs.
+- Play an interactive `/game` quiz that drills your vocabulary pairs.
 
 ## Prerequisites
 
@@ -61,6 +62,15 @@ You can send a CSV file with word pairs to the bot to upload them. Please refer 
   - `/getpair`: Get a random word pair.
   - `/settings`: Configure reminders and pairs per reminder.
   - `/clear`: Clear all uploaded word pairs.
+  - `/game`: Start a five-pair quiz session.
+
+### Game mode
+
+- Start with `/game` in a private chat to launch a quiz session for your account.
+- The bot builds a deck of up to five unique word pairs (two prompt cards per pair, one in each direction) and shuffles them.
+- Answer the prompt directly in chat. Correct answers reveal the pair with a ✅ and remove that card from the deck.
+- Tap the 👀 inline button to reveal the answer. Reveals and incorrect answers both count as misses and return the card to the back of the deck.
+- The session ends when every card is answered correctly or after 15 minutes of inactivity, and the bot reports your correct count and accuracy.
 
 ## Database Setup
 

--- a/cmd/tg-word-reminder/main.go
+++ b/cmd/tg-word-reminder/main.go
@@ -38,9 +38,12 @@ func main() {
 	b.RegisterHandler(bot.HandlerTypeMessageText, "/settings", bot.MatchTypeExact, reminderBot.HandleSettings)
 	b.RegisterHandler(bot.HandlerTypeMessageText, "/clear", bot.MatchTypeExact, reminderBot.HandleClear)
 	b.RegisterHandler(bot.HandlerTypeMessageText, "/getpair", bot.MatchTypeExact, reminderBot.HandleGetPair)
+	b.RegisterHandler(bot.HandlerTypeMessageText, "/game", bot.MatchTypeExact, reminderBot.HandleGame)
 	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, "s:", bot.MatchTypePrefix, reminderBot.HandleSettingsCallback)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, reminderBot.GameCallbackPrefix, bot.MatchTypePrefix, reminderBot.HandleGameReveal)
 
 	go reminderBot.StartPeriodicMessages(ctx, b)
+	go reminderBot.StartGameSweeper(ctx, b)
 
 	logger.Info("Starting bot...")
 	b.Start(ctx)

--- a/pkg/bot/game.go
+++ b/pkg/bot/game.go
@@ -1,0 +1,471 @@
+package bot
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-telegram/bot"
+	"github.com/go-telegram/bot/models"
+	"github.com/smith3v/tg-word-reminder/pkg/db"
+	"github.com/smith3v/tg-word-reminder/pkg/logger"
+)
+
+type cardDirection int
+
+const (
+	cardDirectionAToB cardDirection = iota
+	cardDirectionBToA
+)
+
+type cardResult int
+
+const (
+	resultCorrect cardResult = iota
+	resultIncorrect
+	resultReveal
+)
+
+const (
+	GameCallbackPrefix = "g:"
+	revealCallback     = GameCallbackPrefix + "reveal"
+)
+
+var (
+	gameManager = newGameManager(15 * time.Minute)
+
+	multiSpacePattern   = regexp.MustCompile(`\s+`)
+	trailingPunctuation = regexp.MustCompile(`[.!?,]+$`)
+)
+
+type Card struct {
+	pairID    uint
+	direction cardDirection
+	shown     string
+	expected  string
+}
+
+type GameSession struct {
+	chatID int64
+	userID int64
+
+	startedAt      time.Time
+	lastActivityAt time.Time
+
+	deck             []Card
+	currentCard      *Card
+	currentResolved  bool
+	currentMessageID int
+
+	correctCount int
+	attemptCount int
+}
+
+type GameManager struct {
+	mu         sync.Mutex
+	sessions   map[string]*GameSession
+	timeout    time.Duration
+	now        func() time.Time
+	randSource func() *rand.Rand
+}
+
+func newGameManager(timeout time.Duration) *GameManager {
+	return &GameManager{
+		sessions: make(map[string]*GameSession),
+		timeout:  timeout,
+		now:      time.Now,
+		randSource: func() *rand.Rand {
+			return rand.New(rand.NewSource(time.Now().UnixNano()))
+		},
+	}
+}
+
+func sessionKey(chatID, userID int64) string {
+	return fmt.Sprintf("%d:%d", chatID, userID)
+}
+
+func StartGameSweeper(ctx context.Context, b *bot.Bot) {
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			gameManager.sweepInactiveSessions(ctx, b)
+		}
+	}
+}
+
+func HandleGame(ctx context.Context, b *bot.Bot, update *models.Update) {
+	if update == nil || update.Message == nil || update.Message.From == nil {
+		logger.Error("invalid update in HandleGame")
+		return
+	}
+
+	chatID := update.Message.Chat.ID
+	userID := update.Message.From.ID
+	if chatID == 0 || userID == 0 {
+		logger.Error("chat or user missing in HandleGame")
+		return
+	}
+
+	if err := gameManager.startSession(ctx, b, chatID, userID); err != nil {
+		logger.Error("failed to start game session", "user_id", userID, "error", err)
+	}
+}
+
+func HandleGameAnswer(ctx context.Context, b *bot.Bot, update *models.Update) bool {
+	if update == nil || update.Message == nil || update.Message.From == nil {
+		return false
+	}
+	if update.Message.Chat.ID == 0 || update.Message.From.ID == 0 {
+		return false
+	}
+	if update.Message.Text == "" {
+		return false
+	}
+	handled, err := gameManager.handleAnswer(ctx, b, update.Message.Chat.ID, update.Message.From.ID, update.Message.Text)
+	if err != nil {
+		logger.Error("failed to handle game answer", "user_id", update.Message.From.ID, "error", err)
+	}
+	return handled
+}
+
+func HandleGameReveal(ctx context.Context, b *bot.Bot, update *models.Update) {
+	if update == nil || update.CallbackQuery == nil {
+		logger.Error("invalid update in HandleGameReveal")
+		return
+	}
+
+	if update.CallbackQuery.Data != revealCallback {
+		return
+	}
+
+	if update.CallbackQuery.Message.Type != models.MaybeInaccessibleMessageTypeMessage || update.CallbackQuery.Message.Message == nil {
+		logger.Error("callback query message is inaccessible", "user_id", update.CallbackQuery.From.ID)
+		return
+	}
+
+	msg := update.CallbackQuery.Message.Message
+	handled, err := gameManager.handleReveal(ctx, b, msg.Chat.ID, update.CallbackQuery.From.ID, msg.ID)
+	if err != nil {
+		logger.Error("failed to handle reveal callback", "user_id", update.CallbackQuery.From.ID, "error", err)
+	}
+
+	if _, ansErr := b.AnswerCallbackQuery(ctx, &bot.AnswerCallbackQueryParams{CallbackQueryID: update.CallbackQuery.ID}); ansErr != nil {
+		logger.Error("failed to answer reveal callback", "error", ansErr)
+	}
+
+	if !handled {
+		if _, err := b.SendMessage(ctx, &bot.SendMessageParams{
+			ChatID: msg.Chat.ID,
+			Text:   "No active game session. Send /game to start a new one.",
+		}); err != nil {
+			logger.Error("failed to notify about missing session", "error", err)
+		}
+	}
+}
+
+func (gm *GameManager) startSession(ctx context.Context, b *bot.Bot, chatID, userID int64) error {
+	var wordPairs []db.WordPair
+	if err := db.DB.Where("user_id = ?", userID).Order("RANDOM()").Limit(5).Find(&wordPairs).Error; err != nil {
+		return fmt.Errorf("failed to load word pairs: %w", err)
+	}
+
+	if len(wordPairs) == 0 {
+		_, err := b.SendMessage(ctx, &bot.SendMessageParams{
+			ChatID: chatID,
+			Text:   "You have no word pairs saved. Upload some first to play the game.",
+		})
+		return err
+	}
+
+	randGen := gm.randSource()
+	cards := buildDeck(wordPairs, randGen)
+	if len(cards) == 0 {
+		return errors.New("empty deck generated")
+	}
+
+	key := sessionKey(chatID, userID)
+
+	gm.mu.Lock()
+	_, restarting := gm.sessions[key]
+	now := gm.now()
+	session := &GameSession{
+		chatID:         chatID,
+		userID:         userID,
+		startedAt:      now,
+		lastActivityAt: now,
+		deck:           cards,
+	}
+
+	firstCard := session.deck[0]
+	session.deck = session.deck[1:]
+	session.currentCard = &firstCard
+
+	gm.sessions[key] = session
+	gm.mu.Unlock()
+
+	if restarting {
+		if _, err := b.SendMessage(ctx, &bot.SendMessageParams{
+			ChatID: chatID,
+			Text:   "Starting a new game!",
+		}); err != nil {
+			logger.Error("failed to send restart notification", "user_id", userID, "error", err)
+		}
+	}
+
+	return gm.sendPrompt(ctx, b, session)
+}
+
+func (gm *GameManager) handleAnswer(ctx context.Context, b *bot.Bot, chatID, userID int64, answer string) (bool, error) {
+	key := sessionKey(chatID, userID)
+	gm.mu.Lock()
+	session := gm.sessions[key]
+	if session == nil || session.currentCard == nil {
+		gm.mu.Unlock()
+		return false, nil
+	}
+	if session.currentResolved {
+		gm.mu.Unlock()
+		return true, nil
+	}
+
+	card := *session.currentCard
+	messageID := session.currentMessageID
+	gm.mu.Unlock()
+
+	result := resultIncorrect
+	if normalizeAnswer(answer) == normalizeAnswer(card.expected) {
+		result = resultCorrect
+	}
+
+	if err := gm.resolveCurrent(ctx, b, key, session, card, messageID, result); err != nil {
+		return true, err
+	}
+
+	return true, nil
+}
+
+func (gm *GameManager) handleReveal(ctx context.Context, b *bot.Bot, chatID, userID int64, messageID int) (bool, error) {
+	key := sessionKey(chatID, userID)
+	gm.mu.Lock()
+	session := gm.sessions[key]
+	if session == nil || session.currentCard == nil {
+		gm.mu.Unlock()
+		return false, nil
+	}
+	if session.currentResolved || session.currentMessageID != messageID {
+		gm.mu.Unlock()
+		return true, nil
+	}
+
+	card := *session.currentCard
+	gm.mu.Unlock()
+
+	if err := gm.resolveCurrent(ctx, b, key, session, card, messageID, resultReveal); err != nil {
+		return true, err
+	}
+	return true, nil
+}
+
+func (gm *GameManager) resolveCurrent(ctx context.Context, b *bot.Bot, key string, session *GameSession, card Card, messageID int, result cardResult) error {
+	switch result {
+	case resultCorrect:
+		if err := gm.editPrompt(ctx, b, session.chatID, messageID, card, "✅"); err != nil {
+			logger.Error("failed to edit prompt after correct answer", "error", err)
+		}
+	case resultIncorrect:
+		if err := gm.editPrompt(ctx, b, session.chatID, messageID, card, "❌"); err != nil {
+			logger.Error("failed to edit prompt after incorrect answer", "error", err)
+		}
+	case resultReveal:
+		if err := gm.editPrompt(ctx, b, session.chatID, messageID, card, "👀"); err != nil {
+			logger.Error("failed to edit prompt after reveal", "error", err)
+		}
+	}
+
+	nextCard, finished, stats := gm.advanceSession(key, result)
+
+	if finished {
+		return gm.sendStats(ctx, b, session.chatID, stats)
+	}
+
+	session.currentCard = nextCard
+	return gm.sendPrompt(ctx, b, session)
+}
+
+func (gm *GameManager) advanceSession(key string, result cardResult) (*Card, bool, GameStats) {
+	gm.mu.Lock()
+	defer gm.mu.Unlock()
+
+	session := gm.sessions[key]
+	if session == nil || session.currentCard == nil {
+		return nil, true, GameStats{}
+	}
+
+	session.currentResolved = true
+	session.attemptCount++
+	session.lastActivityAt = gm.now()
+
+	current := *session.currentCard
+
+	if result == resultCorrect {
+		session.correctCount++
+	} else {
+		session.deck = append(session.deck, current)
+	}
+
+	if len(session.deck) == 0 {
+		delete(gm.sessions, key)
+		return nil, true, GameStats{Correct: session.correctCount, Attempts: session.attemptCount}
+	}
+
+	next := session.deck[0]
+	session.deck = session.deck[1:]
+	session.currentCard = &next
+	session.currentResolved = false
+
+	return &next, false, GameStats{Correct: session.correctCount, Attempts: session.attemptCount}
+}
+
+func (gm *GameManager) sendPrompt(ctx context.Context, b *bot.Bot, session *GameSession) error {
+	if session.currentCard == nil {
+		return errors.New("no card to prompt")
+	}
+
+	prompt := formatPrompt(*session.currentCard)
+	keyboard := &models.InlineKeyboardMarkup{InlineKeyboard: [][]models.InlineKeyboardButton{
+		{
+			{Text: "👀", CallbackData: revealCallback},
+		},
+	}}
+
+	msg, err := b.SendMessage(ctx, &bot.SendMessageParams{
+		ChatID:      session.chatID,
+		Text:        prompt,
+		ParseMode:   models.ParseModeMarkdown,
+		ReplyMarkup: keyboard,
+	})
+	if err != nil {
+		return err
+	}
+
+	gm.mu.Lock()
+	session.currentMessageID = msg.ID
+	session.currentResolved = false
+	gm.mu.Unlock()
+
+	return nil
+}
+
+func (gm *GameManager) editPrompt(ctx context.Context, b *bot.Bot, chatID int64, messageID int, card Card, marker string) error {
+	if messageID == 0 {
+		return errors.New("message id is missing")
+	}
+
+	resolved := fmt.Sprintf("*%s — %s %s*", bot.EscapeMarkdown(card.shown), bot.EscapeMarkdown(card.expected), marker)
+	_, err := b.EditMessageText(ctx, &bot.EditMessageTextParams{
+		ChatID:      chatID,
+		MessageID:   messageID,
+		Text:        resolved,
+		ParseMode:   models.ParseModeMarkdown,
+		ReplyMarkup: &models.InlineKeyboardMarkup{InlineKeyboard: [][]models.InlineKeyboardButton{}},
+	})
+	return err
+}
+
+func (gm *GameManager) sendStats(ctx context.Context, b *bot.Bot, chatID int64, stats GameStats) error {
+	accuracy := accuracyPercent(stats.Correct, stats.Attempts)
+	text := fmt.Sprintf("*Game over!*\nYou got *%d* correct answers.\nAccuracy: *%d%%* (%d/%d)", stats.Correct, accuracy, stats.Correct, stats.Attempts)
+	_, err := b.SendMessage(ctx, &bot.SendMessageParams{
+		ChatID:    chatID,
+		Text:      text,
+		ParseMode: models.ParseModeMarkdown,
+	})
+	return err
+}
+
+func (gm *GameManager) sweepInactiveSessions(ctx context.Context, b *bot.Bot) {
+	now := gm.now()
+
+	gm.mu.Lock()
+	expiredKeys := make([]string, 0)
+	statsByKey := make(map[string]GameStats)
+	chatByKey := make(map[string]int64)
+
+	for key, session := range gm.sessions {
+		if now.Sub(session.lastActivityAt) > gm.timeout {
+			statsByKey[key] = GameStats{Correct: session.correctCount, Attempts: session.attemptCount}
+			chatByKey[key] = session.chatID
+			expiredKeys = append(expiredKeys, key)
+			delete(gm.sessions, key)
+		}
+	}
+	gm.mu.Unlock()
+
+	for _, key := range expiredKeys {
+		if err := gm.sendStats(ctx, b, chatByKey[key], statsByKey[key]); err != nil {
+			logger.Error("failed to send timeout stats", "key", key, "error", err)
+		}
+	}
+}
+
+func buildDeck(pairs []db.WordPair, rng *rand.Rand) []Card {
+	cards := make([]Card, 0, len(pairs)*2)
+	for _, pair := range pairs {
+		cards = append(cards, Card{
+			pairID:    pair.ID,
+			direction: cardDirectionAToB,
+			shown:     pair.Word1,
+			expected:  pair.Word2,
+		})
+		cards = append(cards, Card{
+			pairID:    pair.ID,
+			direction: cardDirectionBToA,
+			shown:     pair.Word2,
+			expected:  pair.Word1,
+		})
+	}
+
+	rng.Shuffle(len(cards), func(i, j int) {
+		cards[i], cards[j] = cards[j], cards[i]
+	})
+
+	return cards
+}
+
+func formatPrompt(card Card) string {
+	return fmt.Sprintf("Translate: *%s* → ?\n_(reply with the missing word, or tap 👀 to reveal — counts as a miss)_", bot.EscapeMarkdown(card.shown))
+}
+
+func normalizeAnswer(input string) string {
+	trimmed := strings.TrimSpace(input)
+	lowered := strings.ToLower(trimmed)
+	collapsed := multiSpacePattern.ReplaceAllString(lowered, " ")
+	stripped := trailingPunctuation.ReplaceAllString(collapsed, "")
+	return stripped
+}
+
+type GameStats struct {
+	Correct  int
+	Attempts int
+}
+
+func accuracyPercent(correct, attempts int) int {
+	if attempts == 0 {
+		return 0
+	}
+	return int(0.5 + 100*float64(correct)/float64(attempts))
+}
+
+func sessionTimedOut(lastActivity time.Time, now time.Time, timeout time.Duration) bool {
+	return now.Sub(lastActivity) > timeout
+}

--- a/pkg/bot/game_test.go
+++ b/pkg/bot/game_test.go
@@ -1,0 +1,173 @@
+package bot
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/smith3v/tg-word-reminder/pkg/db"
+)
+
+func TestBuildDeckCreatesTwoCardsPerPair(t *testing.T) {
+	pairs := []db.WordPair{
+		{ID: 1, Word1: "one", Word2: "uno"},
+		{ID: 2, Word1: "two", Word2: "dos"},
+		{ID: 3, Word1: "three", Word2: "tres"},
+	}
+	rng := rand.New(rand.NewSource(1))
+
+	deck := buildDeck(pairs, rng)
+
+	if len(deck) != len(pairs)*2 {
+		t.Fatalf("expected %d cards, got %d", len(pairs)*2, len(deck))
+	}
+
+	counts := make(map[uint]int)
+	directions := make(map[cardDirection]int)
+	for _, card := range deck {
+		counts[card.pairID]++
+		directions[card.direction]++
+	}
+
+	for _, pair := range pairs {
+		if counts[pair.ID] != 2 {
+			t.Fatalf("expected pair %d to appear twice, got %d", pair.ID, counts[pair.ID])
+		}
+	}
+	if directions[cardDirectionAToB] != len(pairs) || directions[cardDirectionBToA] != len(pairs) {
+		t.Fatalf("expected equal directions, got %+v", directions)
+	}
+}
+
+func TestCorrectAnswerRemovesCard(t *testing.T) {
+	gm := newGameManager(time.Minute)
+	gm.now = func() time.Time { return time.Unix(0, 0) }
+
+	current := Card{shown: "hola", expected: "hello"}
+	deck := []Card{{shown: "adios", expected: "bye"}}
+
+	session := &GameSession{
+		chatID:         1,
+		userID:         2,
+		currentCard:    &current,
+		deck:           deck,
+		lastActivityAt: gm.now(),
+	}
+	key := sessionKey(session.chatID, session.userID)
+	gm.sessions[key] = session
+
+	next, finished, stats := gm.advanceSession(key, resultCorrect)
+
+	if finished {
+		t.Fatalf("expected session to continue after correct answer with remaining deck")
+	}
+	if next == nil || next.shown != "adios" {
+		t.Fatalf("expected next card to be drawn from deck, got %#v", next)
+	}
+	if len(session.deck) != 0 {
+		t.Fatalf("expected deck to shrink, got %d", len(session.deck))
+	}
+	if stats.Correct != 1 || stats.Attempts != 1 {
+		t.Fatalf("unexpected stats: %+v", stats)
+	}
+}
+
+func TestIncorrectAnswerRequeuesCard(t *testing.T) {
+	gm := newGameManager(time.Minute)
+	gm.now = func() time.Time { return time.Unix(0, 0) }
+
+	current := Card{shown: "hola", expected: "hello"}
+	deck := []Card{{shown: "adios", expected: "bye"}}
+
+	session := &GameSession{chatID: 1, userID: 2, currentCard: &current, deck: deck}
+	key := sessionKey(session.chatID, session.userID)
+	gm.sessions[key] = session
+
+	next, finished, stats := gm.advanceSession(key, resultIncorrect)
+
+	if finished {
+		t.Fatalf("expected session to continue after incorrect answer")
+	}
+	if next == nil || next.shown != "adios" {
+		t.Fatalf("expected next card from front of deck, got %#v", next)
+	}
+	if len(session.deck) != 1 {
+		t.Fatalf("expected deck to contain requeued card, got %d", len(session.deck))
+	}
+	if session.deck[0].shown != "hola" {
+		t.Fatalf("expected current card to be requeued at back, got %s", session.deck[0].shown)
+	}
+	if stats.Correct != 0 || stats.Attempts != 1 {
+		t.Fatalf("unexpected stats: %+v", stats)
+	}
+}
+
+func TestRevealRequeuesCard(t *testing.T) {
+	gm := newGameManager(time.Minute)
+	gm.now = func() time.Time { return time.Unix(0, 0) }
+
+	current := Card{shown: "hola", expected: "hello"}
+	deck := []Card{{shown: "adios", expected: "bye"}}
+
+	session := &GameSession{chatID: 1, userID: 2, currentCard: &current, deck: deck}
+	key := sessionKey(session.chatID, session.userID)
+	gm.sessions[key] = session
+
+	next, finished, stats := gm.advanceSession(key, resultReveal)
+
+	if finished {
+		t.Fatalf("expected session to continue after reveal")
+	}
+	if next == nil || next.shown != "adios" {
+		t.Fatalf("expected next card from front of deck, got %#v", next)
+	}
+	if len(session.deck) != 1 || session.deck[0].shown != "hola" {
+		t.Fatalf("expected revealed card requeued to back, got %#v", session.deck)
+	}
+	if stats.Correct != 0 || stats.Attempts != 1 {
+		t.Fatalf("unexpected stats: %+v", stats)
+	}
+}
+
+func TestNormalizeAnswer(t *testing.T) {
+	input := "  Hola!!!  "
+	got := normalizeAnswer(input)
+	if got != "hola" {
+		t.Fatalf("expected normalized value 'hola', got %q", got)
+	}
+
+	spaced := "hola    amigo"
+	if normalizeAnswer(spaced) != "hola amigo" {
+		t.Fatalf("expected collapsed spaces, got %q", normalizeAnswer(spaced))
+	}
+}
+
+func TestAccuracyPercent(t *testing.T) {
+	cases := []struct {
+		correct  int
+		attempts int
+		expected int
+	}{
+		{0, 0, 0},
+		{3, 5, 60},
+		{2, 3, 67},
+	}
+
+	for _, tt := range cases {
+		if got := accuracyPercent(tt.correct, tt.attempts); got != tt.expected {
+			t.Fatalf("accuracyPercent(%d, %d) = %d, want %d", tt.correct, tt.attempts, got, tt.expected)
+		}
+	}
+}
+
+func TestSessionTimedOut(t *testing.T) {
+	now := time.Now()
+	timeout := 15 * time.Minute
+
+	if sessionTimedOut(now.Add(-14*time.Minute), now, timeout) {
+		t.Fatalf("expected session to be active")
+	}
+	if !sessionTimedOut(now.Add(-16*time.Minute), now, timeout) {
+		t.Fatalf("expected session to be timed out")
+	}
+}

--- a/pkg/bot/handlers.go
+++ b/pkg/bot/handlers.go
@@ -32,9 +32,13 @@ func DefaultHandler(ctx context.Context, b *bot.Bot, update *models.Update) {
 
 	// Check if the message contains a document (file)
 	if update.Message.Document == nil {
+		if handled := HandleGameAnswer(ctx, b, update); handled {
+			return
+		}
+
 		_, err := b.SendMessage(ctx, &bot.SendMessageParams{
-			ChatID: update.Message.Chat.ID,
-			Text:   "Type /start to initialize the bot\\, /getpair to get a random pair\\, /settings to configure your preferences\\, or /clear to clean up your vocabulary\\.\n\nIf you attach a CSV file here\\, I\\'ll upload the word pairs to your account\\. Please refer to [the example](https://raw.githubusercontent.com/smith3v/tg-word-reminder/refs/heads/main/example.csv) for a file format\\, or to [Dutch\\-English vocabulary example](https://raw.githubusercontent.com/smith3v/tg-word-reminder/refs/heads/main/dutch-english.csv)\\.",
+			ChatID:    update.Message.Chat.ID,
+			Text:      "Type /start to initialize the bot\\, /getpair to get a random pair\\, /settings to configure your preferences\\, or /clear to clean up your vocabulary\\.\n\nIf you attach a CSV file here\\, I\\'ll upload the word pairs to your account\\. Please refer to [the example](https://raw.githubusercontent.com/smith3v/tg-word-reminder/refs/heads/main/example.csv) for a file format\\, or to [Dutch\\-English vocabulary example](https://raw.githubusercontent.com/smith3v/tg-word-reminder/refs/heads/main/dutch-english.csv)\\.",
 			ParseMode: models.ParseModeMarkdown,
 		})
 		if err != nil {


### PR DESCRIPTION
## Summary
- add an in-memory game session manager with deck building, prompt handling, and inactivity cleanup
- wire the new /game command, inline reveal callbacks, and default handler routing
- document the game flow and cover deck, scoring, and timeout logic with unit tests

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c0bbc582083228dec981242fef501)