### PR TITLE
Add /game mode

### DIFF
--- a/cmd/tg-word-reminder/main.go
+++ b/cmd/tg-word-reminder/main.go
@@ -38,6 +38,7 @@ func main() {
 	b.RegisterHandler(bot.HandlerTypeMessageText, "/settings", bot.MatchTypeExact, reminderBot.HandleSettings)
 	b.RegisterHandler(bot.HandlerTypeMessageText, "/clear", bot.MatchTypeExact, reminderBot.HandleClear)
 	b.RegisterHandler(bot.HandlerTypeMessageText, "/getpair", bot.MatchTypeExact, reminderBot.HandleGetPair)
+	b.RegisterHandler(bot.HandlerTypeMessageText, "/game", bot.MatchTypeExact, reminderBot.HandleGameStart)
 	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, "s:", bot.MatchTypePrefix, reminderBot.HandleSettingsCallback)
 
 	go reminderBot.StartPeriodicMessages(ctx, b)

--- a/cmd/tg-word-reminder/main.go
+++ b/cmd/tg-word-reminder/main.go
@@ -40,6 +40,7 @@ func main() {
 	b.RegisterHandler(bot.HandlerTypeMessageText, "/getpair", bot.MatchTypeExact, reminderBot.HandleGetPair)
 	b.RegisterHandler(bot.HandlerTypeMessageText, "/game", bot.MatchTypeExact, reminderBot.HandleGameStart)
 	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, "s:", bot.MatchTypePrefix, reminderBot.HandleSettingsCallback)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, "g:r:", bot.MatchTypePrefix, reminderBot.HandleGameCallback)
 
 	go reminderBot.StartPeriodicMessages(ctx, b)
 

--- a/docs/game.md
+++ b/docs/game.md
@@ -160,6 +160,7 @@ To avoid frustrating “almost correct” mismatches while staying deterministic
 - `strings.ToLower` (or Unicode-aware case fold)
 - Collapse multiple spaces to one
 - Ignore trailing punctuation like `.`, `!`, `?`, `,`
+- If the expected answer contains commas, treat each comma-separated option as an acceptable answer (e.g., `casa, hogar` accepts either).
 
 **Explicitly out of scope (v1):**
 

--- a/docs/game.md
+++ b/docs/game.md
@@ -100,18 +100,18 @@ Each user action that resolves the current prompt counts as an **attempt**:
 
 **Correct typed answer**
 
-- Bot edits the *prompt message* to reveal the full pair and mark it correct:
+- Bot edits the *prompt message* to reveal the full pair with the answer hidden under a spoiler and mark it correct:
 
-> **wordA — wordB ✅**
+> **wordA — ||wordB|| ✅**
 
 - Bot removes the card from the deck.
 - Bot sends the next prompt (if deck not empty).
 
 **Incorrect typed answer**
 
-- Bot edits the *prompt message* to reveal the full pair and remove the inline keyboard:
+- Bot edits the *prompt message* to reveal the full pair with the answer hidden under a spoiler and remove the inline keyboard:
 
-> **wordA — wordB ❌**
+> **wordA — ||wordB|| ❌**
 
 - Bot counts a miss.
 - Bot returns the card to the back of the deck.
@@ -120,9 +120,9 @@ Each user action that resolves the current prompt counts as an **attempt**:
 **👀 Reveal button**
 
 - Bot counts a miss.
-- Bot edits the *prompt message* to show the correct answer):
+- Bot edits the *prompt message* to show the correct answer hidden under a spoiler):
 
-> **wordA — wordB 👀**
+> **wordA — ||wordB|| 👀**
 
 - Bot returns the card to the back of the deck.
 - Bot sends the next prompt.
@@ -309,9 +309,9 @@ Transitions:
 - `/game` starts a session and builds a deck of **5 unique pairs** (or fewer if vocabulary is smaller).
 - The session generates **two cards per pair**, one in each direction.
 - A prompt message includes an inline **👀** button.
-- Pressing 👀 reveals the correct answer by editing the message, counts a miss, and requeues the card.
-- Incorrect typed answers count a miss, reveals the answer and requeue the card.
-- Correct typed answers reveal the full pair by editing the message and permanently remove the card.
+- Pressing 👀 reveals the correct answer (hidden under a spoiler) by editing the message, counts a miss, and requeues the card.
+- Incorrect typed answers count a miss, reveals the answer (hidden under a spoiler) and requeue the card.
+- Correct typed answers reveal the full pair (with the answer hidden under a spoiler) by editing the message and permanently remove the card.
 - Session ends when the **deck becomes empty** or after **15 minutes inactivity**, then prints stats including:
   - correct count (`N`)
   - accuracy percentage (`P%`)

--- a/docs/game.md
+++ b/docs/game.md
@@ -1,0 +1,352 @@
+# Feature Proposal: `/game` — Vocabulary Quiz Mode (5 pairs, deck until empty)
+
+## Background / context
+
+`tg-word-reminder` already supports user-uploaded word pairs and commands like `/getpair`, `/settings`, `/clear`, plus periodic reminders using stored vocabulary.
+
+This proposal adds a conversational mini-game to practice recall in the chat.
+
+## Goals
+
+- Provide an interactive “quiz session” started by `/game`.
+- Each session uses a **fixed deck of 5 unique word pairs**.
+- For each pair, create **two prompt cards**:
+  - **A → ?** (expect B)
+  - **B → ?** (expect A)
+- Shuffle prompt cards at session start (initially **10 cards** when 5 pairs exist).
+- Each prompt message includes an inline button **👀**:
+  - pressing it **reveals the correct answer** by editing the prompt message,
+  - **counts as a miss**, and
+  - **returns the card back into the deck** (so the user will see it again later).
+- Typed answers are evaluated:
+  - if correct: reveal the full pair (edit message) and **remove the card from the deck**,
+  - if incorrect: **count a miss** and **return the card back into the deck** (no reveal).
+- The game can take **more than 10 tries** because missed/revealed cards re-enter the deck.
+- Session ends when:
+  - the **deck is empty** (all prompt cards were answered correctly), or
+  - **15 minutes of inactivity** (no attempts).
+- End-of-session stats:
+  - greet the user with answering **N** times correctly during the session
+  - show **percentage correct** during the session
+
+## Non-goals (for v1)
+
+- No spaced repetition weighting, streaks across days, leaderboards, or global stats.
+- No fuzzy matching beyond basic normalization (optional minimal tolerance only).
+
+---
+
+## Session deck rules (5 pairs)
+
+### Pair selection
+
+- On `/game`, build a deck of **5 distinct pairs** sampled randomly from the user’s vocabulary.
+- If the user has **fewer than 5 pairs**, pick **all available pairs** and build prompt cards for them (deck size becomes `2 * available_pairs`; normally 10 cards when 5 pairs exist).
+
+### Prompt card construction
+
+For each selected pair `(A, B)` generate two prompt cards:
+
+1. Card type `A_to_B`: show `A`, expect `B`
+2. Card type `B_to_A`: show `B`, expect `A`
+
+Shuffle all cards once at session start.
+
+### Deck dynamics
+
+Treat the deck as a queue:
+
+- To ask a question: **draw** (pop) the top card.
+- On **correct typed answer**: card is **completed** (discarded, not returned).
+- On **incorrect typed answer**: card is **returned** to the back of the deck.
+- On **👀 reveal button**: card is **returned** to the back of the deck.
+
+This guarantees the session ends exactly when every card is eventually answered correctly.
+
+---
+
+## UX specification
+
+### Command: `/game`
+
+**Trigger**
+
+- User sends `/game` in a private chat (group chats are not supported for now).
+
+**Bot response (session start)**
+
+- Starts a new “Game Session” tied to `(chat_id, user_id)`.
+- Builds and shuffles the deck (see “Session deck rules”).
+- Immediately posts the first prompt message.
+
+### Prompt message
+
+**Prompt format (example)**
+
+> Translate: **wordA** → ?\
+> *(reply with the missing word, or tap 👀 to reveal — counts as a miss)*
+
+**Inline keyboard**
+
+- One button: **👀**
+- Callback: “reveal this card” for the current prompt
+
+### User answers
+
+Each user action that resolves the current prompt counts as an **attempt**:
+
+- sending a text answer (correct or incorrect), OR
+- pressing 👀
+
+**Correct typed answer**
+
+- Bot edits the *prompt message* to reveal the full pair and mark it correct:
+
+> **wordA — wordB ✅**
+
+- Bot removes the card from the deck.
+- Bot sends the next prompt (if deck not empty).
+
+**Incorrect typed answer**
+
+- Bot edits the *prompt message* to reveal the full pair and remove the inline keyboard:
+
+> **wordA — wordB ❌**
+
+- Bot counts a miss.
+- Bot returns the card to the back of the deck.
+- Bot sends the next prompt.
+
+**👀 Reveal button**
+
+- Bot counts a miss.
+- Bot edits the *prompt message* to show the correct answer):
+
+> **wordA — wordB 👀**
+
+- Bot returns the card to the back of the deck.
+- Bot sends the next prompt.
+
+**Important UX detail**
+
+After a prompt is resolved (by correct answer, incorrect answer, or 👀), the bot should remove/disable the inline keyboard on that message to prevent double-counting via repeated clicks.
+
+### Session end
+
+A session ends when either condition is met:
+
+1. **Deck is empty** (all cards answered correctly), OR
+2. **15 minutes of inactivity** (no attempts)
+
+**Stats message format**
+
+> **Game over!**\
+> You got **N** correct answers.\
+> Accuracy: **P%** (N/M)
+
+Where:
+
+- `N = correctCount`
+- `M = attemptCount`
+- `P = round(100*N/M)` if `M>0`, else `0%`
+
+---
+
+## Answer matching rules (Normalization)
+
+To avoid frustrating “almost correct” mismatches while staying deterministic:
+
+- `strings.TrimSpace`
+- `strings.ToLower` (or Unicode-aware case fold)
+- Collapse multiple spaces to one
+- Ignore trailing punctuation like `.`, `!`, `?`, `,`
+
+**Explicitly out of scope (v1):**
+
+- Levenshtein distance / fuzzy typo tolerance
+- Synonym matching
+
+---
+
+## Data model
+
+### In-memory session (recommended v1)
+
+Because this is a “live chat game” and the bot is typically single-instance/self-hosted, v1 can store sessions in memory.
+
+`GameSession`
+
+- Identity
+  - `chatID int64`
+  - `userID int64`
+- Lifecycle
+  - `startedAt time.Time`
+  - `lastActivityAt time.Time`
+  - `active bool`
+- Deck
+  - `pairs []Pair` (size 5 or fewer)
+  - `deck []Card` (size `2*len(pairs)` at start)
+- Current prompt (one at a time)
+  - `currentCard Card` (or pointer / index)
+  - `currentMessageID int`
+  - `currentResolved bool`
+- Stats
+  - `correctCount int`
+  - `attemptCount int`
+
+`Card`
+
+- `pairID`
+- `direction enum {A_to_B, B_to_A}`
+- `shown string`
+- `expected string`
+
+**Why in-memory**
+
+- Minimal schema changes.
+- Resets naturally on bot restart (acceptable for a “session game”).
+
+---
+
+## State machine
+
+States per `(chat_id, user_id)`:
+
+1. **Idle**
+2. **AwaitingAttempt**
+   - Has a non-empty `deck` and one active `currentCard`
+3. **Finished**
+   - Terminal state; session removed from active map
+
+Transitions:
+
+- Idle → AwaitingAttempt on `/game`
+- AwaitingAttempt → AwaitingAttempt on user attempt:
+  - update `attemptCount++`, `lastActivityAt = now`
+  - if correct: `correctCount++`, discard card
+  - if incorrect or 👀: return card to deck back
+  - if deck empty: finish
+  - else: draw next card, send next prompt
+- AwaitingAttempt → Finished on:
+  - timeout (15 minutes inactivity)
+
+---
+
+## Timeout semantics
+
+**Definition of inactivity**
+
+- No user action that qualifies as an attempt (text answer or 👀 callback) within 15 minutes.
+
+**Timer reset rule**
+
+- On every attempt, update `lastActivityAt = now`.
+
+**Implementation options**
+
+- Per-session `time.Timer` reset on activity (simple, but watch for timer/goroutine leaks), OR
+- Single sweeper goroutine runs every minute:
+  - iterate active sessions
+  - if `now - lastActivityAt > 15m`: finish session and send stats
+
+---
+
+## Telegram API interactions
+
+### Prompt message
+
+- `SendMessage` with:
+  - prompt text
+  - `InlineKeyboardMarkup` containing button **👀**
+  - callback data encoding enough info to map to the active session/card
+
+### On typed answer
+
+- Evaluate answer against `currentCard.expected`.
+- `EditMessageText` (and/or `EditMessageReplyMarkup`) to:
+  - on correct: to reveal full pair and annotate with ✅ and remove keyboard
+  - on incorrect: to reveal full pair and annotate with ❌ and remove keyboard
+
+### On 👀 callback
+
+- Validate callback belongs to the active session and the current message/card.
+- `EditMessageText` to reveal full pair and annotate with 👀.
+- Remove keyboard to prevent repeated clicks.
+- Requeue card.
+
+### Update handling
+
+- Only accept attempts from the same `(chat_id, user_id)` as the session.
+- For safety, ignore late/replayed callbacks by checking `currentMessageID` and `currentResolved`.
+
+---
+
+## Concurrency and edge cases
+
+- **Starting `/game` while a session is active**
+  - restart session (new deck + reset stats) and send “Starting a new game!”
+- **Vocabulary too small**
+  - If fewer than 5 pairs exist, start with fewer pairs (deck size becomes `2*N`).
+- **Edits not allowed**
+  - If Telegram refuses edit, fall back to sending a “wordA — wordB 👀” message and remove keyboard. Count as a miss.
+- **Double-count prevention**
+  - Remove keyboard after resolution.
+
+---
+
+## Metrics (session stats)
+
+- `attemptCount`: increment once per resolved prompt (typed answer or 👀)
+- `correctCount`: increment only on correct typed answers
+- `accuracyPercent`:
+  - if `attemptCount > 0`: `round(100 * correctCount / attemptCount)`
+  - else `0`
+
+---
+
+## Acceptance criteria
+
+- `/game` starts a session and builds a deck of **5 unique pairs** (or fewer if vocabulary is smaller).
+- The session generates **two cards per pair**, one in each direction.
+- A prompt message includes an inline **👀** button.
+- Pressing 👀 reveals the correct answer by editing the message, counts a miss, and requeues the card.
+- Incorrect typed answers count a miss, reveals the answer and requeue the card.
+- Correct typed answers reveal the full pair by editing the message and permanently remove the card.
+- Session ends when the **deck becomes empty** or after **15 minutes inactivity**, then prints stats including:
+  - correct count (`N`)
+  - accuracy percentage (`P%`)
+
+---
+
+## Non-functional requirements
+
+- Minimize chat noise:
+  - prefer editing a single message.
+- Code should be testable. Introduce pure functions when possible.
+- Add the comprehensive tests for the new code.
+
+---
+
+## Testing notes (lightweight)
+
+- Unit tests:
+  - normalization function
+  - deck creation (N pairs → 2N cards)
+  - correctness path removes card
+  - incorrect path requeues card
+  - 👀 path reveals + requeues card
+  - accuracy calculation
+  - timeout decision (`now - lastActivityAt`)
+- Manual tests:
+  - answer correct until deck empty → game ends
+  - use 👀 on some prompts → verify game takes more attempts and stats reflect misses
+  - spam 👀 button → ensure no double-count (keyboard removed + `currentResolved` guard)
+
+---
+
+## Suggested documentation addition
+
+Add a short section to README:
+
+- How to start: `/game`
+- How it works: 5 pairs per session, two directions, 👀 reveals (miss + requeue), ends when deck empty or after 15 minutes inactivity, shows stats.

--- a/pkg/bot/game_session.go
+++ b/pkg/bot/game_session.go
@@ -78,7 +78,8 @@ func getSessionKey(chatID, userID int64) string {
 // StartOrRestart initializes or replaces a session and sets the first prompt.
 func (m *GameManager) StartOrRestart(chatID, userID int64, vocabPairs []db.WordPair) *GameSession {
 	now := m.now()
-	deck := buildDeck(vocabPairs)
+	pairs := samplePairs(vocabPairs, DeckPairs)
+	deck := buildDeck(pairs)
 	shuffleDeck(deck)
 
 	session := &GameSession{
@@ -122,6 +123,19 @@ func buildDeck(pairs []db.WordPair) []Card {
 		deck = append(deck, buildCard(pair, DirectionBToA))
 	}
 	return deck
+}
+
+// samplePairs returns up to limit distinct pairs, choosing randomly when necessary.
+func samplePairs(pairs []db.WordPair, limit int) []db.WordPair {
+	if limit <= 0 || len(pairs) <= limit {
+		return pairs
+	}
+	perm := rand.Perm(len(pairs))
+	selected := make([]db.WordPair, 0, limit)
+	for i := 0; i < limit; i++ {
+		selected = append(selected, pairs[perm[i]])
+	}
+	return selected
 }
 
 // shuffleDeck randomizes card order in place.
@@ -233,5 +247,5 @@ func normalizeAnswer(input string) string {
 			return false
 		}
 	})
-	return trimmed
+	return strings.TrimSpace(trimmed)
 }

--- a/pkg/bot/game_session.go
+++ b/pkg/bot/game_session.go
@@ -299,9 +299,7 @@ func (m *GameManager) ResolveTextAttempt(chatID, userID int64, userText string) 
 		card:            *session.currentCard,
 	}
 
-	normalizedUser := normalizeAnswer(userText)
-	normalizedExpected := normalizeAnswer(session.currentCard.Expected)
-	result.correct = normalizedUser == normalizedExpected
+	result.correct = matchesExpected(userText, session.currentCard.Expected)
 
 	session.attemptCount++
 	if result.correct {
@@ -465,4 +463,22 @@ func normalizeAnswer(input string) string {
 		}
 	})
 	return strings.TrimSpace(trimmed)
+}
+
+func matchesExpected(userText, expected string) bool {
+	normalizedUser := normalizeAnswer(userText)
+	if normalizedUser == "" {
+		return false
+	}
+	options := strings.Split(expected, ",")
+	for _, option := range options {
+		normalizedOption := normalizeAnswer(option)
+		if normalizedOption == "" {
+			continue
+		}
+		if normalizedUser == normalizedOption {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/bot/game_session.go
+++ b/pkg/bot/game_session.go
@@ -1,0 +1,148 @@
+package bot
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/smith3v/tg-word-reminder/pkg/db"
+)
+
+const (
+	DeckPairs         = 5
+	InactivityTimeout = 15 * time.Minute
+	SweeperInterval   = 1 * time.Minute
+)
+
+// CardDirection describes which side of the pair is shown.
+type CardDirection string
+
+const (
+	DirectionAToB CardDirection = "A_to_B"
+	DirectionBToA CardDirection = "B_to_A"
+)
+
+// Card is a single prompt in the game deck.
+type Card struct {
+	PairID    uint
+	Direction CardDirection
+	Word1     string
+	Word2     string
+	Shown     string
+	Expected  string
+}
+
+// GameSession tracks a single user's active game state.
+type GameSession struct {
+	chatID int64
+	userID int64
+
+	startedAt      time.Time
+	lastActivityAt time.Time
+	correctCount   int
+	attemptCount   int
+
+	deck []Card
+
+	currentCard      *Card
+	currentMessageID int
+	currentResolved  bool
+}
+
+var (
+	sessionsMu sync.Mutex
+	sessions   = make(map[string]*GameSession)
+)
+
+// getSessionKey builds the map key for a user's active game session.
+func getSessionKey(chatID, userID int64) string {
+	return fmt.Sprintf("%d:%d", chatID, userID)
+}
+
+// startNewSession initializes a session with a shuffled deck derived from pairs.
+func startNewSession(chatID, userID int64, pairs []db.WordPair) *GameSession {
+	now := time.Now()
+	deck := make([]Card, 0, len(pairs)*2)
+	for _, pair := range pairs {
+		deck = append(deck, buildCard(pair, DirectionAToB))
+		deck = append(deck, buildCard(pair, DirectionBToA))
+	}
+	rand.Shuffle(len(deck), func(i, j int) {
+		deck[i], deck[j] = deck[j], deck[i]
+	})
+
+	session := &GameSession{
+		chatID:          chatID,
+		userID:          userID,
+		startedAt:       now,
+		lastActivityAt:  now,
+		deck:            deck,
+		currentResolved: true,
+	}
+
+	key := getSessionKey(chatID, userID)
+	sessionsMu.Lock()
+	sessions[key] = session
+	sessionsMu.Unlock()
+
+	return session
+}
+
+// popNextCard dequeues the next card and marks it as the current prompt.
+func popNextCard(session *GameSession) (Card, bool) {
+	if session == nil || len(session.deck) == 0 {
+		return Card{}, false
+	}
+	card := session.deck[0]
+	session.deck = session.deck[1:]
+	session.currentCard = &card
+	session.currentResolved = false
+	session.currentMessageID = 0
+	return card, true
+}
+
+// requeueCard appends a card to the end of the session deck.
+func requeueCard(session *GameSession, card Card) {
+	if session == nil {
+		return
+	}
+	session.deck = append(session.deck, card)
+}
+
+// finishSession builds the stats payload for a completed game session.
+func finishSession(session *GameSession) string {
+	if session == nil {
+		return "Game over!\nYou got 0 correct answers.\nAccuracy: 0% (0/0)"
+	}
+	accuracy := 0
+	if session.attemptCount > 0 {
+		accuracy = int(math.Round(float64(session.correctCount) * 100 / float64(session.attemptCount)))
+	}
+	return fmt.Sprintf(
+		"Game over!\nYou got %d correct answers.\nAccuracy: %d%% (%d/%d)",
+		session.correctCount,
+		accuracy,
+		session.correctCount,
+		session.attemptCount,
+	)
+}
+
+func buildCard(pair db.WordPair, direction CardDirection) Card {
+	card := Card{
+		PairID:    pair.ID,
+		Direction: direction,
+		Word1:     pair.Word1,
+		Word2:     pair.Word2,
+	}
+	switch direction {
+	case DirectionAToB:
+		card.Shown = pair.Word1
+		card.Expected = pair.Word2
+	case DirectionBToA:
+		card.Shown = pair.Word2
+		card.Expected = pair.Word1
+	}
+	return card
+}

--- a/pkg/bot/game_session_test.go
+++ b/pkg/bot/game_session_test.go
@@ -484,6 +484,25 @@ func TestResolveTextAttemptIncorrectRequeues(t *testing.T) {
 	}
 }
 
+func TestResolveTextAttemptAcceptsCommaOptions(t *testing.T) {
+	manager := NewGameManager(time.Now)
+	current := Card{PairID: 1, Direction: DirectionAToB, Shown: "hola", Expected: "adios, hasta luego"}
+	session := &GameSession{
+		chatID:           7,
+		userID:           8,
+		currentCard:      &current,
+		currentMessageID: 33,
+		currentResolved:  false,
+		deck:             []Card{},
+	}
+	manager.sessions[getSessionKey(7, 8)] = session
+
+	result := manager.ResolveTextAttempt(7, 8, " Hasta luego ")
+	if !result.handled || !result.correct {
+		t.Fatalf("expected comma option to be accepted, got %+v", result)
+	}
+}
+
 func TestResolveTextAttemptFinishesOnEmptyDeck(t *testing.T) {
 	manager := NewGameManager(time.Now)
 	current := Card{PairID: 1, Direction: DirectionAToB, Shown: "hola", Expected: "adios"}

--- a/pkg/bot/game_session_test.go
+++ b/pkg/bot/game_session_test.go
@@ -1,0 +1,181 @@
+package bot
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/smith3v/tg-word-reminder/pkg/db"
+)
+
+func resetSessions() {
+	sessionsMu.Lock()
+	sessions = make(map[string]*GameSession)
+	sessionsMu.Unlock()
+}
+
+func TestGetSessionKey(t *testing.T) {
+	got := getSessionKey(10, 20)
+	if got != "10:20" {
+		t.Fatalf("expected key to be %q, got %q", "10:20", got)
+	}
+}
+
+func TestStartNewSessionCreatesDeckAndStoresSession(t *testing.T) {
+	resetSessions()
+
+	pairs := []db.WordPair{
+		{ID: 1, UserID: 10, Word1: "hola", Word2: "adios"},
+		{ID: 2, UserID: 10, Word1: "uno", Word2: "dos"},
+	}
+
+	start := time.Now()
+	session := startNewSession(100, 200, pairs)
+	if session == nil {
+		t.Fatalf("expected session to be created")
+	}
+	if session.chatID != 100 || session.userID != 200 {
+		t.Fatalf("unexpected session identifiers: chat=%d user=%d", session.chatID, session.userID)
+	}
+	if session.startedAt.Before(start) || session.lastActivityAt.Before(start) {
+		t.Fatalf("expected timestamps to be initialized")
+	}
+	if session.correctCount != 0 || session.attemptCount != 0 {
+		t.Fatalf("expected counters to start at zero")
+	}
+	if session.currentCard != nil || !session.currentResolved {
+		t.Fatalf("expected no current card and resolved state")
+	}
+	if len(session.deck) != len(pairs)*2 {
+		t.Fatalf("expected deck size %d, got %d", len(pairs)*2, len(session.deck))
+	}
+
+	key := getSessionKey(100, 200)
+	sessionsMu.Lock()
+	stored := sessions[key]
+	sessionsMu.Unlock()
+	if stored != session {
+		t.Fatalf("expected session stored in map")
+	}
+
+	pairByID := map[uint]db.WordPair{
+		1: pairs[0],
+		2: pairs[1],
+	}
+	counts := map[string]int{}
+	for _, card := range session.deck {
+		pair, ok := pairByID[card.PairID]
+		if !ok {
+			t.Fatalf("unexpected pair ID in deck: %d", card.PairID)
+		}
+		if card.Word1 != pair.Word1 || card.Word2 != pair.Word2 {
+			t.Fatalf("card words do not match pair: %+v", card)
+		}
+		switch card.Direction {
+		case DirectionAToB:
+			if card.Shown != card.Word1 || card.Expected != card.Word2 {
+				t.Fatalf("A_to_B card mismatch: %+v", card)
+			}
+		case DirectionBToA:
+			if card.Shown != card.Word2 || card.Expected != card.Word1 {
+				t.Fatalf("B_to_A card mismatch: %+v", card)
+			}
+		default:
+			t.Fatalf("unexpected card direction: %s", card.Direction)
+		}
+		key := fmt.Sprintf("%d:%s", card.PairID, card.Direction)
+		counts[key]++
+	}
+
+	for _, pair := range pairs {
+		for _, direction := range []CardDirection{DirectionAToB, DirectionBToA} {
+			key := fmt.Sprintf("%d:%s", pair.ID, direction)
+			if counts[key] != 1 {
+				t.Fatalf("expected one card for %s, got %d", key, counts[key])
+			}
+		}
+	}
+}
+
+func TestPopNextCardDequeuesAndSetsCurrent(t *testing.T) {
+	card1 := Card{
+		PairID:    1,
+		Direction: DirectionAToB,
+		Word1:     "a",
+		Word2:     "b",
+		Shown:     "a",
+		Expected:  "b",
+	}
+	card2 := Card{
+		PairID:    2,
+		Direction: DirectionBToA,
+		Word1:     "c",
+		Word2:     "d",
+		Shown:     "d",
+		Expected:  "c",
+	}
+	session := &GameSession{
+		deck: []Card{card1, card2},
+	}
+
+	got, ok := popNextCard(session)
+	if !ok {
+		t.Fatalf("expected card to be dequeued")
+	}
+	if got != card1 {
+		t.Fatalf("expected first card, got %+v", got)
+	}
+	if len(session.deck) != 1 || session.deck[0] != card2 {
+		t.Fatalf("expected remaining deck to contain second card")
+	}
+	if session.currentCard == nil || *session.currentCard != card1 {
+		t.Fatalf("expected current card to be set")
+	}
+	if session.currentResolved || session.currentMessageID != 0 {
+		t.Fatalf("expected current card to be unresolved with zero message ID")
+	}
+}
+
+func TestPopNextCardReturnsFalseOnEmptyDeck(t *testing.T) {
+	session := &GameSession{}
+	_, ok := popNextCard(session)
+	if ok {
+		t.Fatalf("expected empty deck to return ok=false")
+	}
+}
+
+func TestRequeueCardAppendsToDeck(t *testing.T) {
+	card := Card{
+		PairID:    3,
+		Direction: DirectionAToB,
+		Word1:     "x",
+		Word2:     "y",
+		Shown:     "x",
+		Expected:  "y",
+	}
+	session := &GameSession{
+		deck: []Card{},
+	}
+	requeueCard(session, card)
+	if len(session.deck) != 1 || session.deck[0] != card {
+		t.Fatalf("expected card to be appended")
+	}
+}
+
+func TestFinishSessionFormatsStats(t *testing.T) {
+	message := finishSession(nil)
+	expected := "Game over!\nYou got 0 correct answers.\nAccuracy: 0% (0/0)"
+	if message != expected {
+		t.Fatalf("unexpected message: %q", message)
+	}
+
+	session := &GameSession{
+		correctCount: 2,
+		attemptCount: 3,
+	}
+	message = finishSession(session)
+	expected = "Game over!\nYou got 2 correct answers.\nAccuracy: 67% (2/3)"
+	if message != expected {
+		t.Fatalf("unexpected stats message: %q", message)
+	}
+}

--- a/pkg/bot/game_session_test.go
+++ b/pkg/bot/game_session_test.go
@@ -68,16 +68,13 @@ func TestStartNewSessionCreatesDeckAndStoresSession(t *testing.T) {
 		if !ok {
 			t.Fatalf("unexpected pair ID in deck: %d", card.PairID)
 		}
-		if card.Word1 != pair.Word1 || card.Word2 != pair.Word2 {
-			t.Fatalf("card words do not match pair: %+v", card)
-		}
 		switch card.Direction {
 		case DirectionAToB:
-			if card.Shown != card.Word1 || card.Expected != card.Word2 {
+			if card.Shown != pair.Word1 || card.Expected != pair.Word2 {
 				t.Fatalf("A_to_B card mismatch: %+v", card)
 			}
 		case DirectionBToA:
-			if card.Shown != card.Word2 || card.Expected != card.Word1 {
+			if card.Shown != pair.Word2 || card.Expected != pair.Word1 {
 				t.Fatalf("B_to_A card mismatch: %+v", card)
 			}
 		default:
@@ -101,16 +98,12 @@ func TestPopNextCardDequeuesAndSetsCurrent(t *testing.T) {
 	card1 := Card{
 		PairID:    1,
 		Direction: DirectionAToB,
-		Word1:     "a",
-		Word2:     "b",
 		Shown:     "a",
 		Expected:  "b",
 	}
 	card2 := Card{
 		PairID:    2,
 		Direction: DirectionBToA,
-		Word1:     "c",
-		Word2:     "d",
 		Shown:     "d",
 		Expected:  "c",
 	}
@@ -148,8 +141,6 @@ func TestRequeueCardAppendsToDeck(t *testing.T) {
 	card := Card{
 		PairID:    3,
 		Direction: DirectionAToB,
-		Word1:     "x",
-		Word2:     "y",
 		Shown:     "x",
 		Expected:  "y",
 	}
@@ -177,5 +168,122 @@ func TestFinishSessionFormatsStats(t *testing.T) {
 	expected = "Game over!\nYou got 2 correct answers.\nAccuracy: 67% (2/3)"
 	if message != expected {
 		t.Fatalf("unexpected stats message: %q", message)
+	}
+}
+
+func TestSelectRandomPairsReturnsDistinctPairs(t *testing.T) {
+	setupTestDB(t)
+
+	userID := int64(800)
+	otherID := int64(801)
+	var pairs []db.WordPair
+	for i := 0; i < 8; i++ {
+		pairs = append(pairs, db.WordPair{
+			UserID: userID,
+			Word1:  fmt.Sprintf("word-%d", i),
+			Word2:  fmt.Sprintf("term-%d", i),
+		})
+	}
+	for i := 0; i < 3; i++ {
+		pairs = append(pairs, db.WordPair{
+			UserID: otherID,
+			Word1:  fmt.Sprintf("other-%d", i),
+			Word2:  fmt.Sprintf("else-%d", i),
+		})
+	}
+	if err := db.DB.Create(&pairs).Error; err != nil {
+		t.Fatalf("failed to seed pairs: %v", err)
+	}
+
+	selected, err := selectRandomPairs(userID, DeckPairs)
+	if err != nil {
+		t.Fatalf("failed to select pairs: %v", err)
+	}
+	if len(selected) != DeckPairs {
+		t.Fatalf("expected %d pairs, got %d", DeckPairs, len(selected))
+	}
+	seen := make(map[uint]struct{})
+	for _, pair := range selected {
+		if pair.UserID != userID {
+			t.Fatalf("expected user_id %d, got %d", userID, pair.UserID)
+		}
+		if _, exists := seen[pair.ID]; exists {
+			t.Fatalf("expected distinct pairs, got duplicate ID %d", pair.ID)
+		}
+		seen[pair.ID] = struct{}{}
+	}
+}
+
+func TestBuildDeckCreatesTwoCardsPerPair(t *testing.T) {
+	pairs := []db.WordPair{
+		{ID: 1, Word1: "uno", Word2: "one"},
+		{ID: 2, Word1: "dos", Word2: "two"},
+	}
+	deck := buildDeck(pairs)
+	if len(deck) != len(pairs)*2 {
+		t.Fatalf("expected %d cards, got %d", len(pairs)*2, len(deck))
+	}
+	counts := make(map[string]int)
+	for _, card := range deck {
+		key := fmt.Sprintf("%d:%s", card.PairID, card.Direction)
+		counts[key]++
+	}
+	for _, pair := range pairs {
+		for _, direction := range []CardDirection{DirectionAToB, DirectionBToA} {
+			key := fmt.Sprintf("%d:%s", pair.ID, direction)
+			if counts[key] != 1 {
+				t.Fatalf("expected one card for %s, got %d", key, counts[key])
+			}
+		}
+	}
+}
+
+func TestShuffleRetainsAllCards(t *testing.T) {
+	pairs := []db.WordPair{
+		{ID: 1, Word1: "uno", Word2: "one"},
+		{ID: 2, Word1: "dos", Word2: "two"},
+		{ID: 3, Word1: "tres", Word2: "three"},
+	}
+	deck := buildDeck(pairs)
+	before := make(map[string]int)
+	for _, card := range deck {
+		key := fmt.Sprintf("%d:%s:%s:%s", card.PairID, card.Direction, card.Shown, card.Expected)
+		before[key]++
+	}
+
+	shuffleDeck(deck)
+
+	after := make(map[string]int)
+	for _, card := range deck {
+		key := fmt.Sprintf("%d:%s:%s:%s", card.PairID, card.Direction, card.Shown, card.Expected)
+		after[key]++
+	}
+	if len(before) != len(after) {
+		t.Fatalf("expected card set size to match after shuffle")
+	}
+	for key, count := range before {
+		if after[key] != count {
+			t.Fatalf("card %s count changed after shuffle", key)
+		}
+	}
+}
+
+func TestBuildCardSetsShownAndExpectedByDirection(t *testing.T) {
+	pair := db.WordPair{ID: 7, Word1: "hola", Word2: "adios"}
+
+	card := buildCard(pair, DirectionAToB)
+	if card.PairID != pair.ID || card.Direction != DirectionAToB {
+		t.Fatalf("unexpected card metadata: %+v", card)
+	}
+	if card.Shown != pair.Word1 || card.Expected != pair.Word2 {
+		t.Fatalf("expected A_to_B mapping, got %+v", card)
+	}
+
+	card = buildCard(pair, DirectionBToA)
+	if card.PairID != pair.ID || card.Direction != DirectionBToA {
+		t.Fatalf("unexpected card metadata: %+v", card)
+	}
+	if card.Shown != pair.Word2 || card.Expected != pair.Word1 {
+		t.Fatalf("expected B_to_A mapping, got %+v", card)
 	}
 }

--- a/pkg/bot/game_session_test.go
+++ b/pkg/bot/game_session_test.go
@@ -324,3 +324,24 @@ func TestBuildCardSetsShownAndExpectedByDirection(t *testing.T) {
 		t.Fatalf("expected B_to_A mapping, got %+v", card)
 	}
 }
+
+func TestNormalizeAnswer(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		{"  Hello  ", "hello"},
+		{"Hello   World", "hello world"},
+		{"Hello, ", "hello"},
+		{"Hello!!!", "hello"},
+		{"Hello ! ", "hello"},
+		{"  ", ""},
+	}
+
+	for _, tc := range cases {
+		got := normalizeAnswer(tc.input)
+		if got != tc.expected {
+			t.Fatalf("normalizeAnswer(%q) = %q, want %q", tc.input, got, tc.expected)
+		}
+	}
+}

--- a/pkg/bot/handlers.go
+++ b/pkg/bot/handlers.go
@@ -482,11 +482,12 @@ func HandleGameCallback(ctx context.Context, b *bot.Bot, update *models.Update) 
 		return
 	}
 
-	revealText := fmt.Sprintf("%s — %s 👀", result.card.Shown, result.card.Expected)
+	revealText := formatGameRevealText(result.card, "👀")
 	if _, err := b.EditMessageText(ctx, &bot.EditMessageTextParams{
 		ChatID:    chatID,
 		MessageID: result.promptMessageID,
 		Text:      revealText,
+		ParseMode: models.ParseModeMarkdown,
 		ReplyMarkup: &models.InlineKeyboardMarkup{
 			InlineKeyboard: [][]models.InlineKeyboardButton{},
 		},
@@ -546,11 +547,12 @@ func handleGameTextAttempt(ctx context.Context, b *bot.Bot, update *models.Updat
 	if result.correct {
 		revealSuffix = "✅"
 	}
-	revealText := fmt.Sprintf("%s — %s %s", result.card.Shown, result.card.Expected, revealSuffix)
+	revealText := formatGameRevealText(result.card, revealSuffix)
 	_, err := b.EditMessageText(ctx, &bot.EditMessageTextParams{
 		ChatID:    chatID,
 		MessageID: result.promptMessageID,
 		Text:      revealText,
+		ParseMode: models.ParseModeMarkdown,
 		ReplyMarkup: &models.InlineKeyboardMarkup{
 			InlineKeyboard: [][]models.InlineKeyboardButton{},
 		},
@@ -603,4 +605,10 @@ func sendGamePrompt(ctx context.Context, b *bot.Bot, chatID int64, card *Card, t
 		Text:        prompt,
 		ReplyMarkup: keyboard,
 	})
+}
+
+func formatGameRevealText(card Card, suffix string) string {
+	shown := bot.EscapeMarkdown(card.Shown)
+	expected := bot.EscapeMarkdown(card.Expected)
+	return fmt.Sprintf("%s — ||%s|| %s", shown, expected, suffix)
 }

--- a/pkg/bot/handlers.go
+++ b/pkg/bot/handlers.go
@@ -38,8 +38,14 @@ func DefaultHandler(ctx context.Context, b *bot.Bot, update *models.Update) {
 			}
 		}
 		_, err := b.SendMessage(ctx, &bot.SendMessageParams{
-			ChatID:    update.Message.Chat.ID,
-			Text:      "Type /start to initialize the bot\\, /getpair to get a random pair\\, /settings to configure your preferences\\, or /clear to clean up your vocabulary\\.\n\nIf you attach a CSV file here\\, I\\'ll upload the word pairs to your account\\. Please refer to [the example](https://raw.githubusercontent.com/smith3v/tg-word-reminder/refs/heads/main/example.csv) for a file format\\, or to [Dutch\\-English vocabulary example](https://raw.githubusercontent.com/smith3v/tg-word-reminder/refs/heads/main/dutch-english.csv)\\.",
+			ChatID: update.Message.Chat.ID,
+			Text: "Commands:\n" +
+				"\\* /start: initialize your account\\.\n" +
+				"\\* /getpair: get a random word pair\\.\n" +
+				"\\* /game: start a quiz session\\.\n" +
+				"\\* /settings: configure reminders and pair counts\\.\n" +
+				"\\* /clear: remove all uploaded word pairs\\.\n\n" +
+				"If you attach a CSV file here\\, I\\'ll upload the word pairs to your account\\. Please refer to [the example](https://raw.githubusercontent.com/smith3v/tg-word-reminder/refs/heads/main/example.csv) for a file format\\, or to [Dutch\\-English vocabulary example](https://raw.githubusercontent.com/smith3v/tg-word-reminder/refs/heads/main/dutch-english.csv)\\.",
 			ParseMode: models.ParseModeMarkdown,
 		})
 		if err != nil {
@@ -161,8 +167,12 @@ func HandleStart(ctx context.Context, b *bot.Bot, update *models.Update) {
 	}
 
 	_, err := b.SendMessage(ctx, &bot.SendMessageParams{
-		ChatID:    update.Message.Chat.ID,
-		Text:      "Welcome\\!\n\nThis bot helps to learn the word pairs or idioms\\, for instance\\, when you learn a language\\. It sends the messages to you with random idioms a few times a day\\. You can configure reminder frequency and pair counts with /settings\\.\n\nTo make it useful, you have to upload your vocabulary first\\. You can submit a CSV file here with the word pairs separated by tabs\\. Please refer to [the example](https://raw.githubusercontent.com/smith3v/tg-word-reminder/refs/heads/main/example.csv) for a file format\\, or to [Dutch\\-English vocabulary](https://raw.githubusercontent.com/smith3v/tg-word-reminder/refs/heads/main/dutch-english.csv)\\. ",
+		ChatID: update.Message.Chat.ID,
+		Text: "Welcome\\!\n\n" +
+			"This bot helps you practice word pairs with short quizzes and reminders\\.\n" +
+			"Start by uploading your vocabulary as a tab\\-separated CSV \\(word1\\<TAB\\>word2\\)\\.\n" +
+			"See the [example format](https://raw.githubusercontent.com/smith3v/tg-word-reminder/refs/heads/main/example.csv) or the [Dutch\\-English sample](https://raw.githubusercontent.com/smith3v/tg-word-reminder/refs/heads/main/dutch-english.csv)\\.\n\n" +
+			"Use /settings to adjust reminder frequency and pair count\\, /getpair for a quick random pair\\, or /game to start a quiz session\\.",
 		ParseMode: models.ParseModeMarkdown,
 	})
 	if err != nil {

--- a/pkg/bot/handlers.go
+++ b/pkg/bot/handlers.go
@@ -429,6 +429,91 @@ func HandleGameStart(ctx context.Context, b *bot.Bot, update *models.Update) {
 	gameManager.SetCurrentMessageID(session, msg.ID)
 }
 
+func HandleGameCallback(ctx context.Context, b *bot.Bot, update *models.Update) {
+	if update == nil || update.CallbackQuery == nil {
+		logger.Error("invalid update in HandleGameCallback")
+		return
+	}
+
+	callbackID := update.CallbackQuery.ID
+	answerCallback := func(text string) {
+		if callbackID == "" {
+			return
+		}
+		if _, err := b.AnswerCallbackQuery(ctx, &bot.AnswerCallbackQueryParams{
+			CallbackQueryID: callbackID,
+			Text:            text,
+		}); err != nil {
+			logger.Error("failed to answer game callback query", "error", err)
+		}
+	}
+
+	data := update.CallbackQuery.Data
+	if !strings.HasPrefix(data, "g:r:") {
+		answerCallback("Not active")
+		return
+	}
+	token := strings.TrimPrefix(data, "g:r:")
+	if token == "" {
+		answerCallback("Not active")
+		return
+	}
+
+	message := update.CallbackQuery.Message
+	if message.Type != models.MaybeInaccessibleMessageTypeMessage || message.Message == nil {
+		answerCallback("Message missing")
+		return
+	}
+	msg := message.Message
+	if msg.Chat.ID == 0 {
+		answerCallback("Message missing")
+		return
+	}
+
+	chatID := msg.Chat.ID
+	userID := update.CallbackQuery.From.ID
+	result := gameManager.ResolveRevealAttempt(chatID, userID, token, msg.ID)
+	if !result.handled {
+		notice := result.notice
+		if notice == "" {
+			notice = "Not active"
+		}
+		answerCallback(notice)
+		return
+	}
+
+	revealText := fmt.Sprintf("%s — %s 👀", result.card.Shown, result.card.Expected)
+	if _, err := b.EditMessageText(ctx, &bot.EditMessageTextParams{
+		ChatID:    chatID,
+		MessageID: result.promptMessageID,
+		Text:      revealText,
+		ReplyMarkup: &models.InlineKeyboardMarkup{
+			InlineKeyboard: [][]models.InlineKeyboardButton{},
+		},
+	}); err != nil {
+		logger.Error("failed to edit game reveal", "user_id", userID, "error", err)
+	}
+
+	answerCallback("")
+
+	if result.statsText != "" {
+		b.SendMessage(ctx, &bot.SendMessageParams{
+			ChatID: chatID,
+			Text:   result.statsText,
+		})
+		return
+	}
+
+	if result.nextCard != nil {
+		nextMsg, err := sendGamePrompt(ctx, b, chatID, result.nextCard, result.nextToken, false)
+		if err != nil {
+			logger.Error("failed to send next game prompt", "user_id", userID, "error", err)
+			return
+		}
+		gameManager.SetCurrentMessageIDForToken(chatID, userID, result.nextToken, nextMsg.ID)
+	}
+}
+
 func handleGameTextAttempt(ctx context.Context, b *bot.Bot, update *models.Update) bool {
 	if update == nil || update.Message == nil || update.Message.From == nil || update.Message.Chat.ID == 0 {
 		return false

--- a/pkg/bot/handlers_test.go
+++ b/pkg/bot/handlers_test.go
@@ -455,3 +455,15 @@ func TestHandleGameCallbackRevealRequeuesAndEdits(t *testing.T) {
 		t.Fatalf("expected reveal marker in edit text")
 	}
 }
+
+func TestFormatGameRevealTextAddsSpoilerAndEscapes(t *testing.T) {
+	card := Card{
+		Shown:    "hello_world",
+		Expected: "word[1]",
+	}
+	got := formatGameRevealText(card, "✅")
+	expected := "hello\\_world — ||word\\[1\\]|| ✅"
+	if got != expected {
+		t.Fatalf("expected %q, got %q", expected, got)
+	}
+}


### PR DESCRIPTION
  - Added the /game feature spec and core game session types, deck building, normalization, and a thread‑safe game manager with tests.
  - Implemented /game start flow, typed answer handling, 👀 reveal callbacks, and inactivity sweeper with replay protection and session expiry stats.
  - Added tests for game flows (start, text attempts, reveal callbacks, timeouts) and adjusted UX: spoiler‑hidden answers, comma‑separated correct options, prompt hint only on first question.
  - Refreshed help and welcome messaging to include /game and clearer onboarding.