### PR TITLE
Add configurable file logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ config.json*
 /tg-word-reminder
 .DS_Store
 .gocache
-pgdata/
-backups/
+pgdata
+backups
+logs

--- a/README.md
+++ b/README.md
@@ -150,7 +150,19 @@ The bot uses a PostgreSQL database. Ensure that the database is set up and acces
 
 ## Logging
 
-The bot uses the standard library's `slog` package for logging. Logs will be printed to the console.
+The bot uses the standard library's `slog` package for logging. Logs are printed to stdout by default.
+
+Optional `config.json` logging settings:
+```json
+"logging": {
+  "level": "info",
+  "file": "/app/logs/tg-word-reminder.log"
+}
+```
+- `level`: `debug`, `info`, or `error` (defaults to `info`).
+- `file`: when set, logs are written to both stdout and the file path.
+
+`compose.yml` mounts `./logs` to `/app/logs` so file logs persist across container restarts.
 
 ## Contributing
 

--- a/cmd/tg-word-reminder/main.go
+++ b/cmd/tg-word-reminder/main.go
@@ -3,7 +3,6 @@ package main
 
 import (
 	"context"
-	"log/slog"
 	"os"
 	"os/signal"
 
@@ -13,9 +12,8 @@ import (
 	"github.com/smith3v/tg-word-reminder/pkg/bot/reminders"
 	"github.com/smith3v/tg-word-reminder/pkg/config"
 	"github.com/smith3v/tg-word-reminder/pkg/db"
+	"github.com/smith3v/tg-word-reminder/pkg/logger"
 )
-
-var logger = slog.Default()
 
 type botSender struct {
 	b *bot.Bot
@@ -30,7 +28,17 @@ func (s botSender) SendMessage(ctx context.Context, chatID int64, text string) e
 }
 
 func main() {
-	config.LoadConfig("config.json")
+	if err := config.LoadConfig("config.json"); err != nil {
+		logger.Error("failed to load config", "error", err)
+		os.Exit(1)
+	}
+	if err := logger.Configure(logger.Options{
+		Level: config.AppConfig.Logging.Level,
+		File:  config.AppConfig.Logging.File,
+	}); err != nil {
+		logger.Error("failed to configure logger", "error", err)
+	}
+
 	if err := db.InitDB(config.AppConfig.Database); err != nil {
 		logger.Error("failed to initialize database", "error", err)
 		os.Exit(1)

--- a/compose.yml
+++ b/compose.yml
@@ -5,6 +5,7 @@ services:
     image: ghcr.io/smith3v/tg-word-reminder:latest
     volumes:
       - ./config.json:/app/config.json:ro
+      - ./logs:/app/logs
     restart: "always"
     depends_on:
       db:

--- a/config.example.json
+++ b/config.example.json
@@ -9,5 +9,9 @@
     },
     "telegram": {
         "token": "YOUR_TELEGRAM_BOT_TOKEN"
+    },
+    "logging": {
+        "level": "info",
+        "file": "/app/logs/tg-word-reminder.log"
     }
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,6 +10,7 @@ import (
 type Config struct {
 	Database DatabaseConfig `json:"database"`
 	Telegram TelegramConfig `json:"telegram"`
+	Logging  LoggingConfig  `json:"logging"`
 }
 
 type DatabaseConfig struct {
@@ -23,6 +24,11 @@ type DatabaseConfig struct {
 
 type TelegramConfig struct {
 	Token string `json:"token"`
+}
+
+type LoggingConfig struct {
+	Level string `json:"level"`
+	File  string `json:"file"`
 }
 
 var AppConfig Config

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,8 +1,13 @@
 package logger
 
 import (
+	"errors"
+	"fmt"
+	"io"
 	"log/slog"
 	"os"
+	"path/filepath"
+	"strings"
 )
 
 type LogLevel int
@@ -22,8 +27,69 @@ func init() {
 	Logger = slog.New(slog.NewTextHandler(os.Stdout, nil))
 }
 
+type Options struct {
+	Level string
+	File  string
+}
+
+func Configure(opts Options) error {
+	level := currentLevel
+	var levelErr error
+	if strings.TrimSpace(opts.Level) != "" {
+		level, levelErr = ParseLogLevel(opts.Level)
+	}
+
+	writer := io.Writer(os.Stdout)
+	var fileErr error
+	if strings.TrimSpace(opts.File) != "" {
+		dir := filepath.Dir(opts.File)
+		if mkErr := os.MkdirAll(dir, 0o755); mkErr != nil {
+			fileErr = mkErr
+		} else {
+			file, openErr := os.OpenFile(opts.File, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+			if openErr != nil {
+				fileErr = openErr
+			} else {
+				writer = io.MultiWriter(os.Stdout, file)
+			}
+		}
+	}
+
+	currentLevel = level
+	Logger = slog.New(slog.NewTextHandler(writer, &slog.HandlerOptions{Level: slogLevel(level)}))
+
+	if levelErr != nil || fileErr != nil {
+		return errors.Join(levelErr, fileErr)
+	}
+	return nil
+}
+
 func SetLogLevel(level LogLevel) {
 	currentLevel = level
+}
+
+func ParseLogLevel(value string) (LogLevel, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "debug":
+		return DEBUG, nil
+	case "info":
+		return INFO, nil
+	case "error":
+		return ERROR, nil
+	default:
+		return INFO, fmt.Errorf("invalid log level %q", value)
+	}
+}
+
+func slogLevel(level LogLevel) slog.Level {
+	switch level {
+	case DEBUG:
+		return slog.LevelDebug
+	case ERROR:
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
 }
 
 func Debug(msg string, args ...any) {

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -3,15 +3,18 @@ package logger
 import (
 	"bytes"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
 
 func TestLogLevelFiltering(t *testing.T) {
 	originalLogger := Logger
+	originalLevel := currentLevel
 	t.Cleanup(func() {
 		Logger = originalLogger
-		SetLogLevel(INFO)
+		SetLogLevel(originalLevel)
 	})
 
 	var buf bytes.Buffer
@@ -24,6 +27,68 @@ func TestLogLevelFiltering(t *testing.T) {
 	output := buf.String()
 	if strings.Contains(output, "debug message should be filtered") {
 		t.Fatalf("debug message was logged at INFO level:\n%s", output)
+	}
+	if !strings.Contains(output, "info message should appear") {
+		t.Fatalf("info message was not logged:\n%s", output)
+	}
+}
+
+func TestConfigureWritesToFileAndRespectsLevel(t *testing.T) {
+	originalLogger := Logger
+	originalLevel := currentLevel
+	t.Cleanup(func() {
+		Logger = originalLogger
+		SetLogLevel(originalLevel)
+	})
+
+	logDir := t.TempDir()
+	logPath := filepath.Join(logDir, "nested", "tg-word-reminder.log")
+	if err := Configure(Options{Level: "error", File: logPath}); err != nil {
+		t.Fatalf("Configure returned error: %v", err)
+	}
+
+	Info("info message should be filtered")
+	Error("error message should appear")
+
+	contents, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("failed to read log file: %v", err)
+	}
+
+	output := string(contents)
+	if strings.Contains(output, "info message should be filtered") {
+		t.Fatalf("info message was logged at ERROR level:\n%s", output)
+	}
+	if !strings.Contains(output, "error message should appear") {
+		t.Fatalf("error message was not logged:\n%s", output)
+	}
+}
+
+func TestConfigureInvalidLevelDefaultsToInfo(t *testing.T) {
+	originalLogger := Logger
+	originalLevel := currentLevel
+	t.Cleanup(func() {
+		Logger = originalLogger
+		SetLogLevel(originalLevel)
+	})
+
+	logDir := t.TempDir()
+	logPath := filepath.Join(logDir, "tg-word-reminder.log")
+	if err := Configure(Options{Level: "verbose", File: logPath}); err == nil {
+		t.Fatalf("expected error for invalid log level")
+	}
+
+	Debug("debug message should be filtered")
+	Info("info message should appear")
+
+	contents, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("failed to read log file: %v", err)
+	}
+
+	output := string(contents)
+	if strings.Contains(output, "debug message should be filtered") {
+		t.Fatalf("debug message was logged at default INFO level:\n%s", output)
 	}
 	if !strings.Contains(output, "info message should appear") {
 		t.Fatalf("info message was not logged:\n%s", output)


### PR DESCRIPTION
Added configurable file+stdout logging with optional logging settings, and mounted a host ./logs directory so log files survive container restarts.

Details:

- Logger now supports Options{Level, File} and writes to stdout only by default; when file is set it uses a multi-writer so docker logs still works. File paths are created if missing (/app/logs/...).
- Config schema includes logging with level + file, and cmd/tg-word-reminder/main.go wires it up on startup.
- compose.yml now mounts ./logs:/app/logs, and config.example.json/README document the new settings.